### PR TITLE
Change doc to show that schedule is a required option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.6
+  - Changed `schedule` entry to show that it is required
+  
+
 ## 4.0.5
   - Docs: Set the default_codec doc attribute.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -114,7 +114,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-proxy>> |<<,>>|No
 | <<plugins-{type}s-{plugin}-request_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-retry_non_idempotent>> |<<boolean,boolean>>|No
-| <<plugins-{type}s-{plugin}-schedule>> |<<hash,hash>>|No
+| <<plugins-{type}s-{plugin}-schedule>> |<<hash,hash>>|Yes
 | <<plugins-{type}s-{plugin}-socket_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|No

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'logstash-input-http_poller'
-  s.version         = '4.0.5'
+  s.version         = '4.0.6'
   s.licenses    = ['Apache License (2.0)']
   s.summary     = "Decodes the output of an HTTP API into events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Customer (and support) pointed out apparent error in doc:
"The Logstash http_poller input plugin indicates the param for schedule as No for required. Description for this param explicitly states there is no default value for this setting, and that it dictates "when to periodically poll from the urls," which implies it IS in fact required. When attempting to use this plugin without the schedule param, Logstash produces the error:

[2018-10-22T11:45:13,334][ERROR][logstash.inputs.http_poller] Missing a required setting for the http_poller input plugin:

  input {
    http_poller {
      schedule => # SETTING MISSING
      ...
    }
  }
We should update docs to reflect that this setting is required."

https://github.com/elastic/docs/issues/443